### PR TITLE
fix: use absolute path for working directory

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -69,7 +69,7 @@ function analyzer(opts: AnalyzerPluginOptions = { analyzerMode: 'server', summar
       store
     },
     configResolved(config) {
-      defaultWd = config.build.outDir ?? config.root
+      defaultWd = path.resolve(config.root, config.build.outDir ?? '')
       logger = config.logger
       workspaceRoot = searchForWorkspaceRoot(config.root)
       analyzerModule.workspaceRoot = workspaceRoot


### PR DESCRIPTION
As `outDir` config is relative to the root of the project, in scenarios where the build is run from a directory other than the project root it resolves incorrectly. Using the absolute path of `root` + `outDir` solves this issue.