### PR TITLE
fix: missing promise awaits on output file write

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -137,15 +137,13 @@ function analyzer(opts: AnalyzerPluginOptions = { analyzerMode: 'server', summar
         case 'json': {
           const p = path.join(defaultWd, opts.fileName ? `${opts.fileName}.json` : 'stats.json')
           const foamModule = analyzerModule.processFoamModule()
-          fsp.writeFile(p, JSON.stringify(foamModule, null, 2), 'utf8')
-          break
+          return fsp.writeFile(p, JSON.stringify(foamModule, null, 2), 'utf8')
         }
         case 'static': {
           const p = path.join(defaultWd, opts.fileName ? `${opts.fileName}.html` : 'stats.html')
           const foamModule = analyzerModule.processFoamModule()
           const html = await renderView(foamModule, { title: reportTitle, mode: 'stat' })
-          fsp.writeFile(p, html, 'utf8')
-          break
+          return fsp.writeFile(p, html, 'utf8')
         }
         case 'server': {
           const foamModule = analyzerModule.processFoamModule()


### PR DESCRIPTION
When using this package I was not seeing any content in the output file on my M1 macbook pro (it was 0 bytes, empty)

After digging into the code I found the writing of the output file was not awaiting or returning the promise. Once I returned the promise I could see the output and everything works as expected.