### PR TITLE
refactor: use default options for flexibility

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -11,6 +11,11 @@ import { analyzerDebug, convertBytes, fsp } from './shared'
 
 const isCI = !!process.env.CI
 
+const defaultOptions: AnalyzerPluginOptions = { 
+  analyzerMode: 'server',
+  summary: true 
+}
+
 function openBrowser(address: string) {
   opener([address])
 }
@@ -49,7 +54,9 @@ function validateChunk(chunk: OutputAsset | OutputChunk, allChunks: OutputBundle
   return [isChunk, isChunk ? chunk.sourcemapFileName : null]
 }
 
-function analyzer(opts: AnalyzerPluginOptions = { analyzerMode: 'server', summary: true }): Plugin {
+function analyzer(opts: AnalyzerPluginOptions): Plugin {
+  opts = opts ? { ...defaultOptions, ...opts } : defaultOptions
+
   const { reportTitle = 'vite-bundle-analyzer' } = opts
   const analyzerModule = createAnalyzerModule(opts?.gzipOptions)
   const store: AnalyzerStore = {

--- a/src/server/interface.ts
+++ b/src/server/interface.ts
@@ -56,13 +56,13 @@ export interface BasicAnalyzerPluginOptions {
 }
 
 export interface AnalyzerPluginOptionsWithServer extends BasicAnalyzerPluginOptions {
-  analyzerMode: 'server'
+  analyzerMode?: 'server'
   analyzerPort?: number | 'auto'
   openAnalyzer?: boolean
 }
 
 export interface AnalyzerPluginOptionsWithStatic extends BasicAnalyzerPluginOptions {
-  analyzerMode: 'static' | 'json'
+  analyzerMode?: 'static' | 'json'
   fileName?: string
 }
 


### PR DESCRIPTION
When the user passes in a configuration item, the default configuration item is lost, and the configuration item should be optional if a default value is provided.

```js
vitePlugins.push(analyzer({
    analyzerPort: '8081',
  }))
```

```
Error: Invalidate Option `analyzerMode`
```

