### PR TITLE
feat: add some feature

### DIFF
--- a/__tests__/stats.spec.ts
+++ b/__tests__/stats.spec.ts
@@ -27,7 +27,7 @@ async function runStatTest(data: ReturnType<typeof createMockStats>) {
 
   analyzerModule.setupRollupChunks({ [chunkName]: { ...chunk, fileName: chunkName }, [sourceMapFileName]: assets })
   analyzerModule.installPluginContext(mockRollupContext)
-  await analyzerModule.addModule({ ...chunk, fileName: chunkName }, sourceMapFileName)
+  await analyzerModule.addModule({ ...chunk, fileName: chunkName })
   const module = analyzerModule.processModule()
   if (Array.isArray(expect)) {
     assert(module[0], expect[0], Object.keys(expect[0]) as (keyof Module)[])

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ const REPORT_TITLE_TEXT = 'Title for bundle report.'
 
 const OPEN_TEXT = 'Open report in default browser.'
 
-const DEFAULT_SIZES_TEXT = 'Default size type. Should be `stat` , `parsed` or `gzip`.'
+const DEFAULT_SIZES_TEXT = 'Default size type. Should be `stat` , `parsed` , `gzip` or `brotli`.'
 
 const SUMMARY_TEXT = 'Show full chunk info to stdout.'
 

--- a/src/client/components/checkbox/checkbox.tsx
+++ b/src/client/components/checkbox/checkbox.tsx
@@ -103,7 +103,9 @@ function CheckboxComponent(props: CheckboxProps) {
       }
     }
   } else {
-    setSelfChecked(checked)
+    if (checked !== selfChecked) {
+      setSelfChecked(checked)
+    }
   }
 
   const handleChange = useCallback((e: React.ChangeEvent) => {

--- a/src/client/components/search-modules.tsx
+++ b/src/client/components/search-modules.tsx
@@ -104,7 +104,7 @@ export function SearchModules<F extends Module>(props: SearchModulesProps<F>) {
                 <ModuleItem name={module.parent.label} stylex={{ fontStyle: 'bold' }} />
                 {module.children.map((child) => (
                   <ModuleItem
-                    key={child.label}
+                    key={child.filename}
                     name={child.label}
                     size={child[extra]}
                     pointer={availableMap[child.label]}

--- a/src/client/components/side-bar/side-bar.tsx
+++ b/src/client/components/side-bar/side-bar.tsx
@@ -126,7 +126,6 @@ export function Sidebar({ onVisibleChange = noop }: SidebarProps) {
                 <div key={button} stylex={{ padding: '5px', boxSizing: 'border-box' }}>
                   <Button
                     onClick={() => handleToggleMode(button)}
-                    // onClick={() => toggleSize(button === 'Gzipped' ? 'gzipSize' : button === 'Stat' ? 'statSize' : 'parsedSize')}
                     auto
                     type={mode === button ? 'secondary' : 'default'}
                     scale={0.7}
@@ -137,41 +136,36 @@ export function Sidebar({ onVisibleChange = noop }: SidebarProps) {
               ))}
             </div>
           </div>
-          {IS_CUSTOM_SIDE_BAR
-            ? (
+          <div>
+            {IS_CUSTOM_SIDE_BAR && (
               <div id="customSideBar">
                 {createElement(ui.SideBar ? ui.SideBar : 'div', null)}
               </div>
-            )
-            : (
-              <>
-                <div>
-                  <Text p b h3>Filter by entrypoints:</Text>
-                  <Select
-                    ref={selectRef}
-                    multiple
-                    scale={0.75}
-                    placeholder="Select endpoints"
-                    width="95.5%"
-                    onChange={handleFilterByEntrypoints}
-                    options={entrypointChunks.map((chunk) => ({ value: chunk.label, label: chunk.label }))}
-                  />
-                </div>
-                <div>
-                  <Text p b h3>Search modules:</Text>
-                  <SearchModules extra={userMode} files={allChunks} />
-                </div>
-                <div>
-                  <Text p b h3>Show Chunks:</Text>
-                  <FileList
-                    files={allChunks}
-                    extra={userMode}
-                    scence={scence}
-                    onChange={(v) => updateScence(new Set(v))}
-                  />
-                </div>
-              </>
             )}
+            <Text p b h3>Filter by entrypoints:</Text>
+            <Select
+              ref={selectRef}
+              multiple
+              scale={0.75}
+              placeholder="Select endpoints"
+              width="95.5%"
+              onChange={handleFilterByEntrypoints}
+              options={entrypointChunks.map((chunk) => ({ value: chunk.label, label: chunk.label }))}
+            />
+          </div>
+          <div>
+            <Text p b h3>Search modules:</Text>
+            <SearchModules extra={userMode} files={allChunks} />
+          </div>
+          <div>
+            <Text p b h3>Show Chunks:</Text>
+            <FileList
+              files={allChunks}
+              extra={userMode}
+              scence={scence}
+              onChange={(v) => updateScence(new Set(v))}
+            />
+          </div>
         </Drawer.Content>
       </Drawer>
     </>

--- a/src/client/components/side-bar/side-bar.tsx
+++ b/src/client/components/side-bar/side-bar.tsx
@@ -14,7 +14,7 @@ import type { SelectInstance } from '../select'
 import { Text } from '../text'
 import { useSidebarState, useToggleDrawerVisible } from './provide'
 
-const MODES = tuple('Stat', 'Parsed', 'Gzipped')
+const MODES = tuple('Stat', 'Parsed', 'Gzipped', 'Brotli')
 
 export type ModeType = typeof MODES[number]
 
@@ -42,7 +42,18 @@ export function Sidebar({ onVisibleChange = noop }: SidebarProps) {
     )
   }, [analyzeModule, userMode, entrypoints])
 
-  const mode = useMemo<ModeType>(() => userMode === 'gzipSize' ? 'Gzipped' : userMode === 'statSize' ? 'Stat' : 'Parsed', [userMode])
+  const mode = useMemo<ModeType>(() => {
+    switch (userMode) {
+      case 'gzipSize':
+        return 'Gzipped'
+      case 'statSize':
+        return 'Stat'
+      case 'parsedSize':
+        return 'Parsed'
+      default:
+        return 'Brotli'
+    }
+  }, [userMode])
 
   const entrypointChunks = useMemo(() => analyzeModule.filter((chunk) => chunk.isEntry), [analyzeModule])
 
@@ -55,6 +66,22 @@ export function Sidebar({ onVisibleChange = noop }: SidebarProps) {
   const handleDrawerClose = () => {
     selectRef.current?.destory()
     toggleDrawerVisible()
+  }
+
+  const handleToggleMode = (mode: ModeType) => {
+    const parsed = (() => {
+      switch (mode) {
+        case 'Gzipped':
+          return 'gzipSize'
+        case 'Stat':
+          return 'statSize'
+        case 'Parsed':
+          return 'parsedSize'
+        default:
+          return 'brotliSize'
+      }
+    })()
+    toggleSize(parsed)
   }
 
   return (
@@ -98,7 +125,8 @@ export function Sidebar({ onVisibleChange = noop }: SidebarProps) {
               {MODES.map((button) => (
                 <div key={button} stylex={{ padding: '5px', boxSizing: 'border-box' }}>
                   <Button
-                    onClick={() => toggleSize(button === 'Gzipped' ? 'gzipSize' : button === 'Stat' ? 'statSize' : 'parsedSize')}
+                    onClick={() => handleToggleMode(button)}
+                    // onClick={() => toggleSize(button === 'Gzipped' ? 'gzipSize' : button === 'Stat' ? 'statSize' : 'parsedSize')}
                     auto
                     type={mode === button ? 'secondary' : 'default'}
                     scale={0.7}

--- a/src/client/context.ts
+++ b/src/client/context.ts
@@ -24,7 +24,8 @@ export interface TreemapConfig {
 export const SIZE_RECORD: Record<typeof window['defaultSizes'], Sizes> = {
   stat: 'statSize',
   gzip: 'gzipSize',
-  parsed: 'parsedSize'
+  parsed: 'parsedSize',
+  brotli: 'brotliSize'
 }
 
 const defaultApplicationContext = <ApplicationConfig> {

--- a/src/client/data.json
+++ b/src/client/data.json
@@ -1,584 +1,669 @@
 [
   {
-    "filename": "assets/index-DvjgQQ47.js",
-    "label": "assets/index-DvjgQQ47.js",
-    "parsedSize": 95942,
-    "mapSize": 336255,
-    "statSize": 186734,
-    "gzipSize": 41662,
+    "filename": "assets/index-B-7zTCMa.js",
+    "label": "assets/index-B-7zTCMa.js",
+    "parsedSize": 96131,
+    "mapSize": 337456,
+    "statSize": 187163,
+    "gzipSize": 41730,
+    "brotliSize": 37005,
     "source": [
       {
-        "gzipSize": 41662,
-        "parsedSize": 95942,
-        "label": "home",
+        "gzipSize": 41730,
+        "brotliSize": 37005,
+        "parsedSize": 96131,
+        "label": "Users",
         "groups": [
           {
-            "gzipSize": 22213,
-            "parsedSize": 44456,
+            "gzipSize": 22282,
+            "brotliSize": 19439,
+            "parsedSize": 44644,
             "label": "src",
             "groups": [
               {
-                "gzipSize": 22056,
-                "parsedSize": 44291,
+                "gzipSize": 22125,
+                "brotliSize": 19317,
+                "parsedSize": 44479,
                 "label": "client",
                 "groups": [
                   {
-                    "gzipSize": 18431,
-                    "parsedSize": 38326,
+                    "gzipSize": 18491,
+                    "brotliSize": 16287,
+                    "parsedSize": 38493,
                     "label": "components",
                     "groups": [
                       {
-                        "gzipSize": 1019,
-                        "parsedSize": 1931,
+                        "gzipSize": 1085,
+                        "brotliSize": 970,
+                        "parsedSize": 2106,
                         "label": "side-bar",
                         "groups": [
                           {
                             "gzipSize": 100,
+                            "brotliSize": 86,
                             "parsedSize": 107,
                             "label": "provide.ts",
-                            "filename": "home/src/client/components/side-bar/provide.ts"
+                            "filename": "Users/src/client/components/side-bar/provide.ts"
                           },
                           {
-                            "gzipSize": 919,
-                            "parsedSize": 1824,
+                            "gzipSize": 985,
+                            "brotliSize": 884,
+                            "parsedSize": 1999,
                             "label": "side-bar.tsx",
-                            "filename": "home/src/client/components/side-bar/side-bar.tsx"
+                            "filename": "Users/src/client/components/side-bar/side-bar.tsx"
                           }
                         ],
-                        "filename": "home/src/client/components/side-bar"
+                        "filename": "Users/src/client/components/side-bar"
                       },
                       {
-                        "gzipSize": 2488,
-                        "parsedSize": 5153,
+                        "gzipSize": 2491,
+                        "brotliSize": 2145,
+                        "parsedSize": 5156,
                         "label": "drawer",
                         "groups": [
                           {
-                            "gzipSize": 410,
-                            "parsedSize": 743,
+                            "gzipSize": 413,
+                            "brotliSize": 346,
+                            "parsedSize": 746,
                             "label": "content.tsx",
-                            "filename": "home/src/client/components/drawer/content.tsx"
+                            "filename": "Users/src/client/components/drawer/content.tsx"
                           },
                           {
                             "gzipSize": 692,
+                            "brotliSize": 600,
                             "parsedSize": 1244,
                             "label": "backdrop.tsx",
-                            "filename": "home/src/client/components/drawer/backdrop.tsx"
+                            "filename": "Users/src/client/components/drawer/backdrop.tsx"
                           },
                           {
                             "gzipSize": 1065,
+                            "brotliSize": 935,
                             "parsedSize": 2766,
                             "label": "wrapper.tsx",
-                            "filename": "home/src/client/components/drawer/wrapper.tsx"
+                            "filename": "Users/src/client/components/drawer/wrapper.tsx"
                           },
                           {
                             "gzipSize": 274,
+                            "brotliSize": 233,
                             "parsedSize": 373,
                             "label": "drawer.tsx",
-                            "filename": "home/src/client/components/drawer/drawer.tsx"
+                            "filename": "Users/src/client/components/drawer/drawer.tsx"
                           },
                           {
                             "gzipSize": 47,
+                            "brotliSize": 31,
                             "parsedSize": 27,
                             "label": "index.ts",
-                            "filename": "home/src/client/components/drawer/index.ts"
+                            "filename": "Users/src/client/components/drawer/index.ts"
                           }
                         ],
-                        "filename": "home/src/client/components/drawer"
+                        "filename": "Users/src/client/components/drawer"
                       },
                       {
-                        "gzipSize": 2636,
-                        "parsedSize": 5358,
+                        "gzipSize": 2633,
+                        "brotliSize": 2356,
+                        "parsedSize": 5355,
                         "label": "checkbox",
                         "groups": [
                           {
                             "gzipSize": 99,
+                            "brotliSize": 84,
                             "parsedSize": 81,
                             "label": "context.ts",
-                            "filename": "home/src/client/components/checkbox/context.ts"
+                            "filename": "Users/src/client/components/checkbox/context.ts"
                           },
                           {
                             "gzipSize": 1363,
+                            "brotliSize": 1219,
                             "parsedSize": 2862,
                             "label": "checkbox.tsx",
-                            "filename": "home/src/client/components/checkbox/checkbox.tsx"
+                            "filename": "Users/src/client/components/checkbox/checkbox.tsx"
                           },
                           {
                             "gzipSize": 682,
+                            "brotliSize": 613,
                             "parsedSize": 1518,
                             "label": "checkbox-group.tsx",
-                            "filename": "home/src/client/components/checkbox/checkbox-group.tsx"
+                            "filename": "Users/src/client/components/checkbox/checkbox-group.tsx"
                           },
                           {
-                            "gzipSize": 492,
-                            "parsedSize": 897,
+                            "gzipSize": 489,
+                            "brotliSize": 440,
+                            "parsedSize": 894,
                             "label": "index.ts",
-                            "filename": "home/src/client/components/checkbox/index.ts"
+                            "filename": "Users/src/client/components/checkbox/index.ts"
                           }
                         ],
-                        "filename": "home/src/client/components/checkbox"
+                        "filename": "Users/src/client/components/checkbox"
                       },
                       {
-                        "gzipSize": 1156,
-                        "parsedSize": 2561,
+                        "gzipSize": 1154,
+                        "brotliSize": 1010,
+                        "parsedSize": 2558,
                         "label": "text",
                         "groups": [
                           {
-                            "gzipSize": 798,
-                            "parsedSize": 1977,
+                            "gzipSize": 796,
+                            "brotliSize": 697,
+                            "parsedSize": 1974,
                             "label": "child.tsx",
-                            "filename": "home/src/client/components/text/child.tsx"
+                            "filename": "Users/src/client/components/text/child.tsx"
                           },
                           {
                             "gzipSize": 358,
+                            "brotliSize": 313,
                             "parsedSize": 584,
                             "label": "text.tsx",
-                            "filename": "home/src/client/components/text/text.tsx"
+                            "filename": "Users/src/client/components/text/text.tsx"
                           }
                         ],
-                        "filename": "home/src/client/components/text"
+                        "filename": "Users/src/client/components/text"
                       },
                       {
                         "gzipSize": 260,
+                        "brotliSize": 226,
                         "parsedSize": 391,
                         "label": "module-item.tsx",
-                        "filename": "home/src/client/components/module-item.tsx"
+                        "filename": "Users/src/client/components/module-item.tsx"
                       },
                       {
                         "gzipSize": 347,
+                        "brotliSize": 306,
                         "parsedSize": 533,
                         "label": "file-list.tsx",
-                        "filename": "home/src/client/components/file-list.tsx"
+                        "filename": "Users/src/client/components/file-list.tsx"
                       },
                       {
                         "gzipSize": 1609,
-                        "parsedSize": 4521,
+                        "brotliSize": 1442,
+                        "parsedSize": 4520,
                         "label": "input",
                         "groups": [
                           {
                             "gzipSize": 1609,
-                            "parsedSize": 4521,
+                            "brotliSize": 1442,
+                            "parsedSize": 4520,
                             "label": "input.tsx",
-                            "filename": "home/src/client/components/input/input.tsx"
+                            "filename": "Users/src/client/components/input/input.tsx"
                           }
                         ],
-                        "filename": "home/src/client/components/input"
+                        "filename": "Users/src/client/components/input"
                       },
                       {
-                        "gzipSize": 660,
-                        "parsedSize": 1273,
+                        "gzipSize": 654,
+                        "brotliSize": 587,
+                        "parsedSize": 1264,
                         "label": "search-modules.tsx",
-                        "filename": "home/src/client/components/search-modules.tsx"
+                        "filename": "Users/src/client/components/search-modules.tsx"
                       },
                       {
-                        "gzipSize": 5041,
-                        "parsedSize": 9522,
+                        "gzipSize": 5045,
+                        "brotliSize": 4405,
+                        "parsedSize": 9531,
                         "label": "select",
                         "groups": [
                           {
                             "gzipSize": 124,
+                            "brotliSize": 98,
                             "parsedSize": 115,
                             "label": "context.ts",
-                            "filename": "home/src/client/components/select/context.ts"
+                            "filename": "Users/src/client/components/select/context.ts"
                           },
                           {
-                            "gzipSize": 234,
-                            "parsedSize": 371,
+                            "gzipSize": 233,
+                            "brotliSize": 211,
+                            "parsedSize": 369,
                             "label": "layouts.ts",
-                            "filename": "home/src/client/components/select/layouts.ts"
+                            "filename": "Users/src/client/components/select/layouts.ts"
                           },
                           {
-                            "gzipSize": 685,
-                            "parsedSize": 1193,
+                            "gzipSize": 690,
+                            "brotliSize": 588,
+                            "parsedSize": 1204,
                             "label": "dropdown.tsx",
-                            "filename": "home/src/client/components/select/dropdown.tsx"
+                            "filename": "Users/src/client/components/select/dropdown.tsx"
                           },
                           {
                             "gzipSize": 216,
+                            "brotliSize": 176,
                             "parsedSize": 267,
                             "label": "ellipsis.tsx",
-                            "filename": "home/src/client/components/select/ellipsis.tsx"
+                            "filename": "Users/src/client/components/select/ellipsis.tsx"
                           },
                           {
                             "gzipSize": 733,
+                            "brotliSize": 632,
                             "parsedSize": 1282,
                             "label": "select-multiple.tsx",
-                            "filename": "home/src/client/components/select/select-multiple.tsx"
+                            "filename": "Users/src/client/components/select/select-multiple.tsx"
                           },
                           {
                             "gzipSize": 1130,
+                            "brotliSize": 983,
                             "parsedSize": 2608,
                             "label": "select-option.tsx",
-                            "filename": "home/src/client/components/select/select-option.tsx"
+                            "filename": "Users/src/client/components/select/select-option.tsx"
                           },
                           {
                             "gzipSize": 1800,
+                            "brotliSize": 1623,
                             "parsedSize": 3580,
                             "label": "select.tsx",
-                            "filename": "home/src/client/components/select/select.tsx"
+                            "filename": "Users/src/client/components/select/select.tsx"
                           },
                           {
                             "gzipSize": 119,
+                            "brotliSize": 94,
                             "parsedSize": 106,
                             "label": "index.ts",
-                            "filename": "home/src/client/components/select/index.ts"
+                            "filename": "Users/src/client/components/select/index.ts"
                           }
                         ],
-                        "filename": "home/src/client/components/select"
+                        "filename": "Users/src/client/components/select"
                       },
                       {
                         "gzipSize": 552,
+                        "brotliSize": 473,
                         "parsedSize": 876,
                         "label": "tooltip.tsx",
-                        "filename": "home/src/client/components/tooltip.tsx"
+                        "filename": "Users/src/client/components/tooltip.tsx"
                       },
                       {
-                        "gzipSize": 516,
-                        "parsedSize": 892,
+                        "gzipSize": 514,
+                        "brotliSize": 464,
+                        "parsedSize": 888,
                         "label": "treemap",
                         "groups": [
                           {
-                            "gzipSize": 516,
-                            "parsedSize": 892,
+                            "gzipSize": 514,
+                            "brotliSize": 464,
+                            "parsedSize": 888,
                             "label": "component.tsx",
-                            "filename": "home/src/client/components/treemap/component.tsx"
+                            "filename": "Users/src/client/components/treemap/component.tsx"
                           }
                         ],
-                        "filename": "home/src/client/components/treemap"
+                        "filename": "Users/src/client/components/treemap"
                       },
                       {
-                        "gzipSize": 1377,
-                        "parsedSize": 3873,
+                        "gzipSize": 1375,
+                        "brotliSize": 1214,
+                        "parsedSize": 3870,
                         "label": "button/button.tsx",
-                        "filename": "home/src/client/components/button/button.tsx"
+                        "filename": "Users/src/client/components/button/button.tsx"
                       },
                       {
                         "gzipSize": 330,
+                        "brotliSize": 308,
                         "parsedSize": 535,
                         "label": "css-transition/css-transition.ts",
-                        "filename": "home/src/client/components/css-transition/css-transition.ts"
+                        "filename": "Users/src/client/components/css-transition/css-transition.ts"
                       },
                       {
-                        "gzipSize": 440,
-                        "parsedSize": 907,
+                        "gzipSize": 442,
+                        "brotliSize": 381,
+                        "parsedSize": 910,
                         "label": "spacer/spacer.tsx",
-                        "filename": "home/src/client/components/spacer/spacer.tsx"
+                        "filename": "Users/src/client/components/spacer/spacer.tsx"
                       }
                     ],
-                    "filename": "home/src/client/components"
+                    "filename": "Users/src/client/components"
                   },
                   {
-                    "gzipSize": 298,
-                    "parsedSize": 471,
+                    "gzipSize": 307,
+                    "brotliSize": 274,
+                    "parsedSize": 491,
                     "label": "context.ts",
-                    "filename": "home/src/client/context.ts"
+                    "filename": "Users/src/client/context.ts"
                   },
                   {
                     "gzipSize": 111,
+                    "brotliSize": 94,
                     "parsedSize": 91,
                     "label": "special",
                     "groups": [
                       {
                         "gzipSize": 111,
+                        "brotliSize": 94,
                         "parsedSize": 91,
                         "label": "index.ts",
-                        "filename": "home/src/client/special/index.ts"
+                        "filename": "Users/src/client/special/index.ts"
                       }
                     ],
-                    "filename": "home/src/client/special"
+                    "filename": "Users/src/client/special"
                   },
                   {
-                    "gzipSize": 2305,
-                    "parsedSize": 3792,
+                    "gzipSize": 2307,
+                    "brotliSize": 1921,
+                    "parsedSize": 3794,
                     "label": "composables",
                     "groups": [
                       {
                         "gzipSize": 449,
+                        "brotliSize": 376,
                         "parsedSize": 887,
                         "label": "use-body-scroll",
                         "groups": [
                           {
                             "gzipSize": 449,
+                            "brotliSize": 376,
                             "parsedSize": 887,
                             "label": "use-body-scroll.ts",
-                            "filename": "home/src/client/composables/use-body-scroll/use-body-scroll.ts"
+                            "filename": "Users/src/client/composables/use-body-scroll/use-body-scroll.ts"
                           }
                         ],
-                        "filename": "home/src/client/composables/use-body-scroll"
+                        "filename": "Users/src/client/composables/use-body-scroll"
                       },
                       {
-                        "gzipSize": 179,
-                        "parsedSize": 214,
+                        "gzipSize": 174,
+                        "brotliSize": 151,
+                        "parsedSize": 205,
                         "label": "use-dom-observer",
                         "groups": [
                           {
-                            "gzipSize": 179,
-                            "parsedSize": 214,
+                            "gzipSize": 174,
+                            "brotliSize": 151,
+                            "parsedSize": 205,
                             "label": "use-dom-observer.ts",
-                            "filename": "home/src/client/composables/use-dom-observer/use-dom-observer.ts"
+                            "filename": "Users/src/client/composables/use-dom-observer/use-dom-observer.ts"
                           }
                         ],
-                        "filename": "home/src/client/composables/use-dom-observer"
+                        "filename": "Users/src/client/composables/use-dom-observer"
                       },
                       {
                         "gzipSize": 217,
+                        "brotliSize": 167,
                         "parsedSize": 254,
                         "label": "use-portal",
                         "groups": [
                           {
                             "gzipSize": 217,
+                            "brotliSize": 167,
                             "parsedSize": 254,
                             "label": "use-portal.ts",
-                            "filename": "home/src/client/composables/use-portal/use-portal.ts"
+                            "filename": "Users/src/client/composables/use-portal/use-portal.ts"
                           }
                         ],
-                        "filename": "home/src/client/composables/use-portal"
+                        "filename": "Users/src/client/composables/use-portal"
                       },
                       {
                         "gzipSize": 132,
+                        "brotliSize": 114,
                         "parsedSize": 157,
                         "label": "use-resize",
                         "groups": [
                           {
                             "gzipSize": 132,
+                            "brotliSize": 114,
                             "parsedSize": 157,
                             "label": "use-resize.ts",
-                            "filename": "home/src/client/composables/use-resize/use-resize.ts"
+                            "filename": "Users/src/client/composables/use-resize/use-resize.ts"
                           }
                         ],
-                        "filename": "home/src/client/composables/use-resize"
+                        "filename": "Users/src/client/composables/use-resize"
                       },
                       {
                         "gzipSize": 1066,
+                        "brotliSize": 920,
                         "parsedSize": 1779,
                         "label": "use-scale",
                         "groups": [
                           {
                             "gzipSize": 291,
+                            "brotliSize": 246,
                             "parsedSize": 491,
                             "label": "scale-context.ts",
-                            "filename": "home/src/client/composables/use-scale/scale-context.ts"
+                            "filename": "Users/src/client/composables/use-scale/scale-context.ts"
                           },
                           {
                             "gzipSize": 147,
+                            "brotliSize": 122,
                             "parsedSize": 188,
                             "label": "utils.ts",
-                            "filename": "home/src/client/composables/use-scale/utils.ts"
+                            "filename": "Users/src/client/composables/use-scale/utils.ts"
                           },
                           {
                             "gzipSize": 628,
+                            "brotliSize": 552,
                             "parsedSize": 1100,
                             "label": "with-scale.tsx",
-                            "filename": "home/src/client/composables/use-scale/with-scale.tsx"
+                            "filename": "Users/src/client/composables/use-scale/with-scale.tsx"
                           }
                         ],
-                        "filename": "home/src/client/composables/use-scale"
+                        "filename": "Users/src/client/composables/use-scale"
                       },
                       {
                         "gzipSize": 86,
+                        "brotliSize": 64,
                         "parsedSize": 97,
                         "label": "use-click-anywhere",
                         "groups": [
                           {
                             "gzipSize": 86,
+                            "brotliSize": 64,
                             "parsedSize": 97,
                             "label": "use-click-anywhere.ts",
-                            "filename": "home/src/client/composables/use-click-anywhere/use-click-anywhere.ts"
+                            "filename": "Users/src/client/composables/use-click-anywhere/use-click-anywhere.ts"
                           }
                         ],
-                        "filename": "home/src/client/composables/use-click-anywhere"
+                        "filename": "Users/src/client/composables/use-click-anywhere"
                       },
                       {
-                        "gzipSize": 176,
-                        "parsedSize": 404,
+                        "gzipSize": 183,
+                        "brotliSize": 129,
+                        "parsedSize": 415,
                         "label": "use-query",
                         "groups": [
                           {
-                            "gzipSize": 176,
-                            "parsedSize": 404,
+                            "gzipSize": 183,
+                            "brotliSize": 129,
+                            "parsedSize": 415,
                             "label": "use-query.ts",
-                            "filename": "home/src/client/composables/use-query/use-query.ts"
+                            "filename": "Users/src/client/composables/use-query/use-query.ts"
                           }
                         ],
-                        "filename": "home/src/client/composables/use-query"
+                        "filename": "Users/src/client/composables/use-query"
                       }
                     ],
-                    "filename": "home/src/client/composables"
+                    "filename": "Users/src/client/composables"
                   },
                   {
                     "gzipSize": 117,
-                    "parsedSize": 118,
+                    "brotliSize": 90,
+                    "parsedSize": 119,
                     "label": "shared.ts",
-                    "filename": "home/src/client/shared.ts"
+                    "filename": "Users/src/client/shared.ts"
                   },
                   {
-                    "gzipSize": 227,
-                    "parsedSize": 415,
+                    "gzipSize": 225,
+                    "brotliSize": 172,
+                    "parsedSize": 413,
                     "label": "receiver.tsx",
-                    "filename": "home/src/client/receiver.tsx"
+                    "filename": "Users/src/client/receiver.tsx"
                   },
                   {
                     "gzipSize": 449,
+                    "brotliSize": 395,
                     "parsedSize": 963,
                     "label": "application.tsx",
-                    "filename": "home/src/client/application.tsx"
+                    "filename": "Users/src/client/application.tsx"
                   },
                   {
                     "gzipSize": 118,
+                    "brotliSize": 84,
                     "parsedSize": 115,
                     "label": "main.tsx",
-                    "filename": "home/src/client/main.tsx"
+                    "filename": "Users/src/client/main.tsx"
                   }
                 ],
-                "filename": "home/src/client"
+                "filename": "Users/src/client"
               },
               {
                 "gzipSize": 157,
+                "brotliSize": 122,
                 "parsedSize": 165,
                 "label": "shared/index.ts",
-                "filename": "home/src/shared/index.ts"
+                "filename": "Users/src/shared/index.ts"
               }
             ],
-            "filename": "home/src"
+            "filename": "Users/src"
           },
           {
-            "gzipSize": 19449,
-            "parsedSize": 51486,
+            "gzipSize": 19448,
+            "brotliSize": 17566,
+            "parsedSize": 51487,
             "label": "node_modules/.pnpm",
             "groups": [
               {
                 "gzipSize": 8135,
-                "parsedSize": 25437,
+                "brotliSize": 7334,
+                "parsedSize": 25438,
                 "label": "squarified@0.2.2/node_modules/squarified/dist/index.mjs",
-                "filename": "home/node_modules/.pnpm/squarified@0.2.2/node_modules/squarified/dist/index.mjs"
+                "filename": "Users/node_modules/.pnpm/squarified@0.2.2/node_modules/squarified/dist/index.mjs"
               },
               {
-                "gzipSize": 9915,
+                "gzipSize": 9914,
+                "brotliSize": 9042,
                 "parsedSize": 23893,
                 "label": "preact@10.22.0/node_modules/preact",
                 "groups": [
                   {
                     "gzipSize": 3725,
+                    "brotliSize": 3411,
                     "parsedSize": 9109,
                     "label": "compat",
                     "groups": [
                       {
                         "gzipSize": 119,
+                        "brotliSize": 101,
                         "parsedSize": 143,
                         "label": "client.mjs",
-                        "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/compat/client.mjs"
+                        "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/compat/client.mjs"
                       },
                       {
                         "gzipSize": 3606,
+                        "brotliSize": 3310,
                         "parsedSize": 8966,
                         "label": "dist/compat.module.js",
-                        "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/compat/dist/compat.module.js"
+                        "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/compat/dist/compat.module.js"
                       }
                     ],
-                    "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/compat"
+                    "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/compat"
                   },
                   {
-                    "gzipSize": 4563,
+                    "gzipSize": 4562,
+                    "brotliSize": 4154,
                     "parsedSize": 11051,
                     "label": "dist/preact.module.js",
-                    "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/dist/preact.module.js"
+                    "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/dist/preact.module.js"
                   },
                   {
                     "gzipSize": 1370,
+                    "brotliSize": 1255,
                     "parsedSize": 3367,
                     "label": "hooks/dist",
                     "groups": [
                       {
                         "gzipSize": 1370,
+                        "brotliSize": 1255,
                         "parsedSize": 3367,
                         "label": "hooks.module.js",
-                        "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/hooks/dist/hooks.module.js"
+                        "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/hooks/dist/hooks.module.js"
                       }
                     ],
-                    "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/hooks/dist"
+                    "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/hooks/dist"
                   },
                   {
                     "gzipSize": 257,
+                    "brotliSize": 222,
                     "parsedSize": 366,
                     "label": "jsx-runtime/dist",
                     "groups": [
                       {
                         "gzipSize": 257,
+                        "brotliSize": 222,
                         "parsedSize": 366,
                         "label": "jsxRuntime.module.js",
-                        "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js"
+                        "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js"
                       }
                     ],
-                    "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/jsx-runtime/dist"
+                    "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/jsx-runtime/dist"
                   }
                 ],
-                "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact"
+                "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact"
               },
               {
                 "gzipSize": 792,
+                "brotliSize": 710,
                 "parsedSize": 1422,
                 "label": "@stylexjs+stylex@0.6.1/node_modules/@stylexjs/stylex/lib/es/stylex.mjs",
-                "filename": "home/node_modules/.pnpm/@stylexjs+stylex@0.6.1/node_modules/@stylexjs/stylex/lib/es/stylex.mjs"
+                "filename": "Users/node_modules/.pnpm/@stylexjs+stylex@0.6.1/node_modules/@stylexjs/stylex/lib/es/stylex.mjs"
               },
               {
                 "gzipSize": 372,
+                "brotliSize": 292,
                 "parsedSize": 375,
                 "label": "foxact@0.2.35_react@18.3.1/node_modules/foxact",
                 "groups": [
                   {
                     "gzipSize": 99,
+                    "brotliSize": 74,
                     "parsedSize": 91,
                     "label": "compose-context-provider/index.mjs",
-                    "filename": "home/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/compose-context-provider/index.mjs"
+                    "filename": "Users/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/compose-context-provider/index.mjs"
                   },
                   {
                     "gzipSize": 30,
+                    "brotliSize": 14,
                     "parsedSize": 10,
                     "label": "noop/index.mjs",
-                    "filename": "home/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/noop/index.mjs"
+                    "filename": "Users/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/noop/index.mjs"
                   },
                   {
                     "gzipSize": 137,
+                    "brotliSize": 120,
                     "parsedSize": 175,
                     "label": "context-state/index.mjs",
-                    "filename": "home/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/context-state/index.mjs"
+                    "filename": "Users/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/context-state/index.mjs"
                   },
                   {
                     "gzipSize": 106,
+                    "brotliSize": 84,
                     "parsedSize": 99,
                     "label": "use-abortable-effect/index.mjs",
-                    "filename": "home/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/use-abortable-effect/index.mjs"
+                    "filename": "Users/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/use-abortable-effect/index.mjs"
                   }
                 ],
-                "filename": "home/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact"
+                "filename": "Users/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact"
               },
               {
                 "gzipSize": 235,
+                "brotliSize": 188,
                 "parsedSize": 359,
                 "label": "clsx@2.1.1/node_modules/clsx/dist/clsx.mjs",
-                "filename": "home/node_modules/.pnpm/clsx@2.1.1/node_modules/clsx/dist/clsx.mjs"
+                "filename": "Users/node_modules/.pnpm/clsx@2.1.1/node_modules/clsx/dist/clsx.mjs"
               }
             ],
-            "filename": "home/node_modules/.pnpm"
+            "filename": "Users/node_modules/.pnpm"
           }
         ],
-        "filename": "home"
+        "filename": "Users"
       }
     ],
     "stats": [
       {
-        "statSize": 97417,
+        "statSize": 97846,
         "label": "src",
         "groups": [
           {
-            "statSize": 97015,
+            "statSize": 97444,
             "label": "client",
             "groups": [
               {
-                "statSize": 79448,
+                "statSize": 79855,
                 "label": "components",
                 "groups": [
                   {
-                    "statSize": 6270,
+                    "statSize": 6691,
                     "label": "side-bar",
                     "groups": [
                       {
@@ -587,7 +672,7 @@
                         "filename": "src/client/components/side-bar/provide.ts"
                       },
                       {
-                        "statSize": 5745,
+                        "statSize": 6166,
                         "label": "side-bar.tsx",
                         "filename": "src/client/components/side-bar/side-bar.tsx"
                       }
@@ -681,11 +766,11 @@
                     "filename": "src/client/components/file-list.tsx"
                   },
                   {
-                    "statSize": 7973,
+                    "statSize": 7959,
                     "label": "input",
                     "groups": [
                       {
-                        "statSize": 7973,
+                        "statSize": 7959,
                         "label": "input.tsx",
                         "filename": "src/client/components/input/input.tsx"
                       }
@@ -780,7 +865,7 @@
                 "filename": "src/client/components"
               },
               {
-                "statSize": 1694,
+                "statSize": 1718,
                 "label": "context.ts",
                 "filename": "src/client/context.ts"
               },
@@ -903,7 +988,7 @@
                 "filename": "src/client/composables"
               },
               {
-                "statSize": 1045,
+                "statSize": 1043,
                 "label": "receiver.tsx",
                 "filename": "src/client/receiver.tsx"
               },

--- a/src/client/data.json
+++ b/src/client/data.json
@@ -1,35 +1,63 @@
 [
   {
-    "filename": "assets/index-B-7zTCMa.js",
-    "label": "assets/index-B-7zTCMa.js",
-    "parsedSize": 96131,
-    "mapSize": 337456,
-    "statSize": 187163,
-    "gzipSize": 41730,
-    "brotliSize": 37005,
+    "filename": "assets/index-x1XGuNl0.css",
+    "label": "assets/index-x1XGuNl0.css",
+    "parsedSize": 1,
+    "mapSize": 0,
+    "statSize": 1,
+    "gzipSize": 21,
+    "brotliSize": 5,
     "source": [
       {
-        "gzipSize": 41730,
-        "brotliSize": 37005,
-        "parsedSize": 96131,
-        "label": "Users",
+        "parsedSize": 1,
+        "gzipSize": 21,
+        "brotliSize": 5,
+        "label": "assets/index-x1XGuNl0.css",
+        "filename": "assets/index-x1XGuNl0.css"
+      }
+    ],
+    "stats": [
+      {
+        "statSize": 1,
+        "label": "assets/index-x1XGuNl0.css",
+        "filename": "assets/index-x1XGuNl0.css"
+      }
+    ],
+    "isAsset": true,
+    "isEntry": false,
+    "imports": []
+  },
+  {
+    "filename": "assets/index-1JenBilL.js",
+    "label": "assets/index-1JenBilL.js",
+    "parsedSize": 96141,
+    "mapSize": 336912,
+    "statSize": 187209,
+    "gzipSize": 41737,
+    "brotliSize": 37065,
+    "source": [
+      {
+        "gzipSize": 41737,
+        "brotliSize": 37065,
+        "parsedSize": 96141,
+        "label": "home",
         "groups": [
           {
-            "gzipSize": 22282,
-            "brotliSize": 19439,
-            "parsedSize": 44644,
+            "gzipSize": 22286,
+            "brotliSize": 19499,
+            "parsedSize": 44650,
             "label": "src",
             "groups": [
               {
-                "gzipSize": 22125,
-                "brotliSize": 19317,
-                "parsedSize": 44479,
+                "gzipSize": 22129,
+                "brotliSize": 19377,
+                "parsedSize": 44485,
                 "label": "client",
                 "groups": [
                   {
-                    "gzipSize": 18491,
-                    "brotliSize": 16287,
-                    "parsedSize": 38493,
+                    "gzipSize": 18493,
+                    "brotliSize": 16349,
+                    "parsedSize": 38495,
                     "label": "components",
                     "groups": [
                       {
@@ -43,66 +71,66 @@
                             "brotliSize": 86,
                             "parsedSize": 107,
                             "label": "provide.ts",
-                            "filename": "Users/src/client/components/side-bar/provide.ts"
+                            "filename": "home/src/client/components/side-bar/provide.ts"
                           },
                           {
                             "gzipSize": 985,
                             "brotliSize": 884,
                             "parsedSize": 1999,
                             "label": "side-bar.tsx",
-                            "filename": "Users/src/client/components/side-bar/side-bar.tsx"
+                            "filename": "home/src/client/components/side-bar/side-bar.tsx"
                           }
                         ],
-                        "filename": "Users/src/client/components/side-bar"
+                        "filename": "home/src/client/components/side-bar"
                       },
                       {
-                        "gzipSize": 2491,
-                        "brotliSize": 2145,
-                        "parsedSize": 5156,
+                        "gzipSize": 2484,
+                        "brotliSize": 2175,
+                        "parsedSize": 5144,
                         "label": "drawer",
                         "groups": [
                           {
-                            "gzipSize": 413,
-                            "brotliSize": 346,
-                            "parsedSize": 746,
+                            "gzipSize": 410,
+                            "brotliSize": 378,
+                            "parsedSize": 743,
                             "label": "content.tsx",
-                            "filename": "Users/src/client/components/drawer/content.tsx"
+                            "filename": "home/src/client/components/drawer/content.tsx"
                           },
                           {
                             "gzipSize": 692,
                             "brotliSize": 600,
                             "parsedSize": 1244,
                             "label": "backdrop.tsx",
-                            "filename": "Users/src/client/components/drawer/backdrop.tsx"
+                            "filename": "home/src/client/components/drawer/backdrop.tsx"
                           },
                           {
                             "gzipSize": 1065,
                             "brotliSize": 935,
                             "parsedSize": 2766,
                             "label": "wrapper.tsx",
-                            "filename": "Users/src/client/components/drawer/wrapper.tsx"
+                            "filename": "home/src/client/components/drawer/wrapper.tsx"
                           },
                           {
-                            "gzipSize": 274,
-                            "brotliSize": 233,
-                            "parsedSize": 373,
+                            "gzipSize": 270,
+                            "brotliSize": 231,
+                            "parsedSize": 364,
                             "label": "drawer.tsx",
-                            "filename": "Users/src/client/components/drawer/drawer.tsx"
+                            "filename": "home/src/client/components/drawer/drawer.tsx"
                           },
                           {
                             "gzipSize": 47,
                             "brotliSize": 31,
                             "parsedSize": 27,
                             "label": "index.ts",
-                            "filename": "Users/src/client/components/drawer/index.ts"
+                            "filename": "home/src/client/components/drawer/index.ts"
                           }
                         ],
-                        "filename": "Users/src/client/components/drawer"
+                        "filename": "home/src/client/components/drawer"
                       },
                       {
-                        "gzipSize": 2633,
-                        "brotliSize": 2356,
-                        "parsedSize": 5355,
+                        "gzipSize": 2635,
+                        "brotliSize": 2369,
+                        "parsedSize": 5362,
                         "label": "checkbox",
                         "groups": [
                           {
@@ -110,31 +138,31 @@
                             "brotliSize": 84,
                             "parsedSize": 81,
                             "label": "context.ts",
-                            "filename": "Users/src/client/components/checkbox/context.ts"
+                            "filename": "home/src/client/components/checkbox/context.ts"
                           },
                           {
-                            "gzipSize": 1363,
-                            "brotliSize": 1219,
-                            "parsedSize": 2862,
+                            "gzipSize": 1365,
+                            "brotliSize": 1232,
+                            "parsedSize": 2869,
                             "label": "checkbox.tsx",
-                            "filename": "Users/src/client/components/checkbox/checkbox.tsx"
+                            "filename": "home/src/client/components/checkbox/checkbox.tsx"
                           },
                           {
                             "gzipSize": 682,
                             "brotliSize": 613,
                             "parsedSize": 1518,
                             "label": "checkbox-group.tsx",
-                            "filename": "Users/src/client/components/checkbox/checkbox-group.tsx"
+                            "filename": "home/src/client/components/checkbox/checkbox-group.tsx"
                           },
                           {
                             "gzipSize": 489,
                             "brotliSize": 440,
                             "parsedSize": 894,
                             "label": "index.ts",
-                            "filename": "Users/src/client/components/checkbox/index.ts"
+                            "filename": "home/src/client/components/checkbox/index.ts"
                           }
                         ],
-                        "filename": "Users/src/client/components/checkbox"
+                        "filename": "home/src/client/components/checkbox"
                       },
                       {
                         "gzipSize": 1154,
@@ -147,31 +175,31 @@
                             "brotliSize": 697,
                             "parsedSize": 1974,
                             "label": "child.tsx",
-                            "filename": "Users/src/client/components/text/child.tsx"
+                            "filename": "home/src/client/components/text/child.tsx"
                           },
                           {
                             "gzipSize": 358,
                             "brotliSize": 313,
                             "parsedSize": 584,
                             "label": "text.tsx",
-                            "filename": "Users/src/client/components/text/text.tsx"
+                            "filename": "home/src/client/components/text/text.tsx"
                           }
                         ],
-                        "filename": "Users/src/client/components/text"
+                        "filename": "home/src/client/components/text"
                       },
                       {
                         "gzipSize": 260,
                         "brotliSize": 226,
                         "parsedSize": 391,
                         "label": "module-item.tsx",
-                        "filename": "Users/src/client/components/module-item.tsx"
+                        "filename": "home/src/client/components/module-item.tsx"
                       },
                       {
                         "gzipSize": 347,
                         "brotliSize": 306,
                         "parsedSize": 533,
                         "label": "file-list.tsx",
-                        "filename": "Users/src/client/components/file-list.tsx"
+                        "filename": "home/src/client/components/file-list.tsx"
                       },
                       {
                         "gzipSize": 1609,
@@ -184,17 +212,17 @@
                             "brotliSize": 1442,
                             "parsedSize": 4520,
                             "label": "input.tsx",
-                            "filename": "Users/src/client/components/input/input.tsx"
+                            "filename": "home/src/client/components/input/input.tsx"
                           }
                         ],
-                        "filename": "Users/src/client/components/input"
+                        "filename": "home/src/client/components/input"
                       },
                       {
-                        "gzipSize": 654,
-                        "brotliSize": 587,
-                        "parsedSize": 1264,
+                        "gzipSize": 659,
+                        "brotliSize": 604,
+                        "parsedSize": 1268,
                         "label": "search-modules.tsx",
-                        "filename": "Users/src/client/components/search-modules.tsx"
+                        "filename": "home/src/client/components/search-modules.tsx"
                       },
                       {
                         "gzipSize": 5045,
@@ -207,66 +235,66 @@
                             "brotliSize": 98,
                             "parsedSize": 115,
                             "label": "context.ts",
-                            "filename": "Users/src/client/components/select/context.ts"
+                            "filename": "home/src/client/components/select/context.ts"
                           },
                           {
                             "gzipSize": 233,
                             "brotliSize": 211,
                             "parsedSize": 369,
                             "label": "layouts.ts",
-                            "filename": "Users/src/client/components/select/layouts.ts"
+                            "filename": "home/src/client/components/select/layouts.ts"
                           },
                           {
                             "gzipSize": 690,
                             "brotliSize": 588,
                             "parsedSize": 1204,
                             "label": "dropdown.tsx",
-                            "filename": "Users/src/client/components/select/dropdown.tsx"
+                            "filename": "home/src/client/components/select/dropdown.tsx"
                           },
                           {
                             "gzipSize": 216,
                             "brotliSize": 176,
                             "parsedSize": 267,
                             "label": "ellipsis.tsx",
-                            "filename": "Users/src/client/components/select/ellipsis.tsx"
+                            "filename": "home/src/client/components/select/ellipsis.tsx"
                           },
                           {
                             "gzipSize": 733,
                             "brotliSize": 632,
                             "parsedSize": 1282,
                             "label": "select-multiple.tsx",
-                            "filename": "Users/src/client/components/select/select-multiple.tsx"
+                            "filename": "home/src/client/components/select/select-multiple.tsx"
                           },
                           {
                             "gzipSize": 1130,
                             "brotliSize": 983,
                             "parsedSize": 2608,
                             "label": "select-option.tsx",
-                            "filename": "Users/src/client/components/select/select-option.tsx"
+                            "filename": "home/src/client/components/select/select-option.tsx"
                           },
                           {
                             "gzipSize": 1800,
                             "brotliSize": 1623,
                             "parsedSize": 3580,
                             "label": "select.tsx",
-                            "filename": "Users/src/client/components/select/select.tsx"
+                            "filename": "home/src/client/components/select/select.tsx"
                           },
                           {
                             "gzipSize": 119,
                             "brotliSize": 94,
                             "parsedSize": 106,
                             "label": "index.ts",
-                            "filename": "Users/src/client/components/select/index.ts"
+                            "filename": "home/src/client/components/select/index.ts"
                           }
                         ],
-                        "filename": "Users/src/client/components/select"
+                        "filename": "home/src/client/components/select"
                       },
                       {
                         "gzipSize": 552,
                         "brotliSize": 473,
                         "parsedSize": 876,
                         "label": "tooltip.tsx",
-                        "filename": "Users/src/client/components/tooltip.tsx"
+                        "filename": "home/src/client/components/tooltip.tsx"
                       },
                       {
                         "gzipSize": 514,
@@ -279,79 +307,79 @@
                             "brotliSize": 464,
                             "parsedSize": 888,
                             "label": "component.tsx",
-                            "filename": "Users/src/client/components/treemap/component.tsx"
+                            "filename": "home/src/client/components/treemap/component.tsx"
                           }
                         ],
-                        "filename": "Users/src/client/components/treemap"
+                        "filename": "home/src/client/components/treemap"
                       },
                       {
-                        "gzipSize": 1375,
-                        "brotliSize": 1214,
-                        "parsedSize": 3870,
+                        "gzipSize": 1377,
+                        "brotliSize": 1216,
+                        "parsedSize": 3873,
                         "label": "button/button.tsx",
-                        "filename": "Users/src/client/components/button/button.tsx"
+                        "filename": "home/src/client/components/button/button.tsx"
                       },
                       {
                         "gzipSize": 330,
                         "brotliSize": 308,
                         "parsedSize": 535,
                         "label": "css-transition/css-transition.ts",
-                        "filename": "Users/src/client/components/css-transition/css-transition.ts"
+                        "filename": "home/src/client/components/css-transition/css-transition.ts"
                       },
                       {
                         "gzipSize": 442,
                         "brotliSize": 381,
                         "parsedSize": 910,
                         "label": "spacer/spacer.tsx",
-                        "filename": "Users/src/client/components/spacer/spacer.tsx"
+                        "filename": "home/src/client/components/spacer/spacer.tsx"
                       }
                     ],
-                    "filename": "Users/src/client/components"
+                    "filename": "home/src/client/components"
                   },
                   {
                     "gzipSize": 307,
                     "brotliSize": 274,
                     "parsedSize": 491,
                     "label": "context.ts",
-                    "filename": "Users/src/client/context.ts"
+                    "filename": "home/src/client/context.ts"
                   },
                   {
-                    "gzipSize": 111,
-                    "brotliSize": 94,
-                    "parsedSize": 91,
+                    "gzipSize": 107,
+                    "brotliSize": 89,
+                    "parsedSize": 87,
                     "label": "special",
                     "groups": [
                       {
-                        "gzipSize": 111,
-                        "brotliSize": 94,
-                        "parsedSize": 91,
+                        "gzipSize": 107,
+                        "brotliSize": 89,
+                        "parsedSize": 87,
                         "label": "index.ts",
-                        "filename": "Users/src/client/special/index.ts"
+                        "filename": "home/src/client/special/index.ts"
                       }
                     ],
-                    "filename": "Users/src/client/special"
+                    "filename": "home/src/client/special"
                   },
                   {
-                    "gzipSize": 2307,
-                    "brotliSize": 1921,
-                    "parsedSize": 3794,
+                    "gzipSize": 2313,
+                    "brotliSize": 1924,
+                    "parsedSize": 3803,
                     "label": "composables",
                     "groups": [
                       {
-                        "gzipSize": 449,
-                        "brotliSize": 376,
-                        "parsedSize": 887,
+                        "gzipSize": 455,
+                        "brotliSize": 379,
+                        "parsedSize": 896,
                         "label": "use-body-scroll",
                         "groups": [
                           {
-                            "gzipSize": 449,
-                            "brotliSize": 376,
-                            "parsedSize": 887,
+                            "gzipSize": 455,
+                            "brotliSize": 379,
+                            "parsedSize": 896,
                             "label": "use-body-scroll.ts",
-                            "filename": "Users/src/client/composables/use-body-scroll/use-body-scroll.ts"
+                            "filename": "home/src/client/composables/use-body-scroll/use-body-scroll.ts"
                           }
                         ],
-                        "filename": "Users/src/client/composables/use-body-scroll"
+                        "filename": "home/src/client/composables/use-body-scroll"
                       },
                       {
                         "gzipSize": 174,
@@ -364,10 +392,10 @@
                             "brotliSize": 151,
                             "parsedSize": 205,
                             "label": "use-dom-observer.ts",
-                            "filename": "Users/src/client/composables/use-dom-observer/use-dom-observer.ts"
+                            "filename": "home/src/client/composables/use-dom-observer/use-dom-observer.ts"
                           }
                         ],
-                        "filename": "Users/src/client/composables/use-dom-observer"
+                        "filename": "home/src/client/composables/use-dom-observer"
                       },
                       {
                         "gzipSize": 217,
@@ -380,10 +408,10 @@
                             "brotliSize": 167,
                             "parsedSize": 254,
                             "label": "use-portal.ts",
-                            "filename": "Users/src/client/composables/use-portal/use-portal.ts"
+                            "filename": "home/src/client/composables/use-portal/use-portal.ts"
                           }
                         ],
-                        "filename": "Users/src/client/composables/use-portal"
+                        "filename": "home/src/client/composables/use-portal"
                       },
                       {
                         "gzipSize": 132,
@@ -396,10 +424,10 @@
                             "brotliSize": 114,
                             "parsedSize": 157,
                             "label": "use-resize.ts",
-                            "filename": "Users/src/client/composables/use-resize/use-resize.ts"
+                            "filename": "home/src/client/composables/use-resize/use-resize.ts"
                           }
                         ],
-                        "filename": "Users/src/client/composables/use-resize"
+                        "filename": "home/src/client/composables/use-resize"
                       },
                       {
                         "gzipSize": 1066,
@@ -412,24 +440,24 @@
                             "brotliSize": 246,
                             "parsedSize": 491,
                             "label": "scale-context.ts",
-                            "filename": "Users/src/client/composables/use-scale/scale-context.ts"
+                            "filename": "home/src/client/composables/use-scale/scale-context.ts"
                           },
                           {
                             "gzipSize": 147,
                             "brotliSize": 122,
                             "parsedSize": 188,
                             "label": "utils.ts",
-                            "filename": "Users/src/client/composables/use-scale/utils.ts"
+                            "filename": "home/src/client/composables/use-scale/utils.ts"
                           },
                           {
                             "gzipSize": 628,
                             "brotliSize": 552,
                             "parsedSize": 1100,
                             "label": "with-scale.tsx",
-                            "filename": "Users/src/client/composables/use-scale/with-scale.tsx"
+                            "filename": "home/src/client/composables/use-scale/with-scale.tsx"
                           }
                         ],
-                        "filename": "Users/src/client/composables/use-scale"
+                        "filename": "home/src/client/composables/use-scale"
                       },
                       {
                         "gzipSize": 86,
@@ -442,10 +470,10 @@
                             "brotliSize": 64,
                             "parsedSize": 97,
                             "label": "use-click-anywhere.ts",
-                            "filename": "Users/src/client/composables/use-click-anywhere/use-click-anywhere.ts"
+                            "filename": "home/src/client/composables/use-click-anywhere/use-click-anywhere.ts"
                           }
                         ],
-                        "filename": "Users/src/client/composables/use-click-anywhere"
+                        "filename": "home/src/client/composables/use-click-anywhere"
                       },
                       {
                         "gzipSize": 183,
@@ -458,59 +486,59 @@
                             "brotliSize": 129,
                             "parsedSize": 415,
                             "label": "use-query.ts",
-                            "filename": "Users/src/client/composables/use-query/use-query.ts"
+                            "filename": "home/src/client/composables/use-query/use-query.ts"
                           }
                         ],
-                        "filename": "Users/src/client/composables/use-query"
+                        "filename": "home/src/client/composables/use-query"
                       }
                     ],
-                    "filename": "Users/src/client/composables"
+                    "filename": "home/src/client/composables"
                   },
                   {
                     "gzipSize": 117,
                     "brotliSize": 90,
-                    "parsedSize": 119,
+                    "parsedSize": 118,
                     "label": "shared.ts",
-                    "filename": "Users/src/client/shared.ts"
+                    "filename": "home/src/client/shared.ts"
                   },
                   {
                     "gzipSize": 225,
                     "brotliSize": 172,
                     "parsedSize": 413,
                     "label": "receiver.tsx",
-                    "filename": "Users/src/client/receiver.tsx"
+                    "filename": "home/src/client/receiver.tsx"
                   },
                   {
                     "gzipSize": 449,
                     "brotliSize": 395,
                     "parsedSize": 963,
                     "label": "application.tsx",
-                    "filename": "Users/src/client/application.tsx"
+                    "filename": "home/src/client/application.tsx"
                   },
                   {
                     "gzipSize": 118,
                     "brotliSize": 84,
                     "parsedSize": 115,
                     "label": "main.tsx",
-                    "filename": "Users/src/client/main.tsx"
+                    "filename": "home/src/client/main.tsx"
                   }
                 ],
-                "filename": "Users/src/client"
+                "filename": "home/src/client"
               },
               {
                 "gzipSize": 157,
                 "brotliSize": 122,
                 "parsedSize": 165,
                 "label": "shared/index.ts",
-                "filename": "Users/src/shared/index.ts"
+                "filename": "home/src/shared/index.ts"
               }
             ],
-            "filename": "Users/src"
+            "filename": "home/src"
           },
           {
-            "gzipSize": 19448,
+            "gzipSize": 19451,
             "brotliSize": 17566,
-            "parsedSize": 51487,
+            "parsedSize": 51491,
             "label": "node_modules/.pnpm",
             "groups": [
               {
@@ -518,18 +546,18 @@
                 "brotliSize": 7334,
                 "parsedSize": 25438,
                 "label": "squarified@0.2.2/node_modules/squarified/dist/index.mjs",
-                "filename": "Users/node_modules/.pnpm/squarified@0.2.2/node_modules/squarified/dist/index.mjs"
+                "filename": "home/node_modules/.pnpm/squarified@0.2.2/node_modules/squarified/dist/index.mjs"
               },
               {
-                "gzipSize": 9914,
-                "brotliSize": 9042,
+                "gzipSize": 9916,
+                "brotliSize": 9040,
                 "parsedSize": 23893,
                 "label": "preact@10.22.0/node_modules/preact",
                 "groups": [
                   {
-                    "gzipSize": 3725,
-                    "brotliSize": 3411,
-                    "parsedSize": 9109,
+                    "gzipSize": 3726,
+                    "brotliSize": 3408,
+                    "parsedSize": 9100,
                     "label": "compat",
                     "groups": [
                       {
@@ -537,24 +565,24 @@
                         "brotliSize": 101,
                         "parsedSize": 143,
                         "label": "client.mjs",
-                        "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/compat/client.mjs"
+                        "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/compat/client.mjs"
                       },
                       {
-                        "gzipSize": 3606,
-                        "brotliSize": 3310,
-                        "parsedSize": 8966,
+                        "gzipSize": 3607,
+                        "brotliSize": 3307,
+                        "parsedSize": 8957,
                         "label": "dist/compat.module.js",
-                        "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/compat/dist/compat.module.js"
+                        "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/compat/dist/compat.module.js"
                       }
                     ],
-                    "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/compat"
+                    "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/compat"
                   },
                   {
-                    "gzipSize": 4562,
-                    "brotliSize": 4154,
-                    "parsedSize": 11051,
+                    "gzipSize": 4563,
+                    "brotliSize": 4155,
+                    "parsedSize": 11060,
                     "label": "dist/preact.module.js",
-                    "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/dist/preact.module.js"
+                    "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/dist/preact.module.js"
                   },
                   {
                     "gzipSize": 1370,
@@ -567,10 +595,10 @@
                         "brotliSize": 1255,
                         "parsedSize": 3367,
                         "label": "hooks.module.js",
-                        "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/hooks/dist/hooks.module.js"
+                        "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/hooks/dist/hooks.module.js"
                       }
                     ],
-                    "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/hooks/dist"
+                    "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/hooks/dist"
                   },
                   {
                     "gzipSize": 257,
@@ -583,20 +611,20 @@
                         "brotliSize": 222,
                         "parsedSize": 366,
                         "label": "jsxRuntime.module.js",
-                        "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js"
+                        "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js"
                       }
                     ],
-                    "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact/jsx-runtime/dist"
+                    "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact/jsx-runtime/dist"
                   }
                 ],
-                "filename": "Users/node_modules/.pnpm/preact@10.22.0/node_modules/preact"
+                "filename": "home/node_modules/.pnpm/preact@10.22.0/node_modules/preact"
               },
               {
                 "gzipSize": 792,
                 "brotliSize": 710,
                 "parsedSize": 1422,
                 "label": "@stylexjs+stylex@0.6.1/node_modules/@stylexjs/stylex/lib/es/stylex.mjs",
-                "filename": "Users/node_modules/.pnpm/@stylexjs+stylex@0.6.1/node_modules/@stylexjs/stylex/lib/es/stylex.mjs"
+                "filename": "home/node_modules/.pnpm/@stylexjs+stylex@0.6.1/node_modules/@stylexjs/stylex/lib/es/stylex.mjs"
               },
               {
                 "gzipSize": 372,
@@ -609,57 +637,57 @@
                     "brotliSize": 74,
                     "parsedSize": 91,
                     "label": "compose-context-provider/index.mjs",
-                    "filename": "Users/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/compose-context-provider/index.mjs"
+                    "filename": "home/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/compose-context-provider/index.mjs"
                   },
                   {
                     "gzipSize": 30,
                     "brotliSize": 14,
                     "parsedSize": 10,
                     "label": "noop/index.mjs",
-                    "filename": "Users/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/noop/index.mjs"
+                    "filename": "home/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/noop/index.mjs"
                   },
                   {
                     "gzipSize": 137,
                     "brotliSize": 120,
                     "parsedSize": 175,
                     "label": "context-state/index.mjs",
-                    "filename": "Users/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/context-state/index.mjs"
+                    "filename": "home/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/context-state/index.mjs"
                   },
                   {
                     "gzipSize": 106,
                     "brotliSize": 84,
                     "parsedSize": 99,
                     "label": "use-abortable-effect/index.mjs",
-                    "filename": "Users/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/use-abortable-effect/index.mjs"
+                    "filename": "home/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact/use-abortable-effect/index.mjs"
                   }
                 ],
-                "filename": "Users/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact"
+                "filename": "home/node_modules/.pnpm/foxact@0.2.35_react@18.3.1/node_modules/foxact"
               },
               {
-                "gzipSize": 235,
-                "brotliSize": 188,
-                "parsedSize": 359,
+                "gzipSize": 236,
+                "brotliSize": 190,
+                "parsedSize": 363,
                 "label": "clsx@2.1.1/node_modules/clsx/dist/clsx.mjs",
-                "filename": "Users/node_modules/.pnpm/clsx@2.1.1/node_modules/clsx/dist/clsx.mjs"
+                "filename": "home/node_modules/.pnpm/clsx@2.1.1/node_modules/clsx/dist/clsx.mjs"
               }
             ],
-            "filename": "Users/node_modules/.pnpm"
+            "filename": "home/node_modules/.pnpm"
           }
         ],
-        "filename": "Users"
+        "filename": "home"
       }
     ],
     "stats": [
       {
-        "statSize": 97846,
+        "statSize": 97892,
         "label": "src",
         "groups": [
           {
-            "statSize": 97444,
+            "statSize": 97490,
             "label": "client",
             "groups": [
               {
-                "statSize": 79855,
+                "statSize": 79901,
                 "label": "components",
                 "groups": [
                   {
@@ -712,7 +740,7 @@
                     "filename": "src/client/components/drawer"
                   },
                   {
-                    "statSize": 9182,
+                    "statSize": 9225,
                     "label": "checkbox",
                     "groups": [
                       {
@@ -721,7 +749,7 @@
                         "filename": "src/client/components/checkbox/context.ts"
                       },
                       {
-                        "statSize": 5555,
+                        "statSize": 5598,
                         "label": "checkbox.tsx",
                         "filename": "src/client/components/checkbox/checkbox.tsx"
                       },
@@ -778,7 +806,7 @@
                     "filename": "src/client/components/input"
                   },
                   {
-                    "statSize": 3843,
+                    "statSize": 3846,
                     "label": "search-modules.tsx",
                     "filename": "src/client/components/search-modules.tsx"
                   },
@@ -1118,6 +1146,34 @@
     ],
     "isAsset": true,
     "isEntry": true,
+    "imports": []
+  },
+  {
+    "filename": "index.html",
+    "label": "index.html",
+    "parsedSize": 1776,
+    "mapSize": 0,
+    "statSize": 1776,
+    "gzipSize": 1132,
+    "brotliSize": 958,
+    "source": [
+      {
+        "parsedSize": 1776,
+        "gzipSize": 1132,
+        "brotliSize": 958,
+        "label": "index.html",
+        "filename": "index.html"
+      }
+    ],
+    "stats": [
+      {
+        "statSize": 1776,
+        "label": "index.html",
+        "filename": "index.html"
+      }
+    ],
+    "isAsset": true,
+    "isEntry": false,
     "imports": []
   }
 ]

--- a/src/client/interface.ts
+++ b/src/client/interface.ts
@@ -1,3 +1,3 @@
 export type Module = typeof window['analyzeModule'][number]
 
-export type Sizes = keyof Pick<Module, 'gzipSize' | 'statSize' | 'parsedSize'>
+export type Sizes = keyof Pick<Module, 'gzipSize' | 'statSize' | 'parsedSize' | 'brotliSize'>

--- a/src/server/analyzer-module.ts
+++ b/src/server/analyzer-module.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import type { BrotliOptions, ZlibOptions } from 'zlib'
 import type { Module, OutputAsset, OutputBundle, OutputChunk, PluginContext } from './interface'
 import { createBrotil, createGzip, slash, stringToByte } from './shared'
-import { pickupMappingsFromCodeBinary } from './source-map'
+import { pickupContentFromSourcemap, pickupMappingsFromCodeBinary } from './source-map'
 import { createFileSystemTrie } from './trie'
 import type { ChunkMetadata, GroupWithNode, KindSource, KindStat } from './trie'
 
@@ -175,7 +175,7 @@ export class AnalyzerNode {
           }
           return acc
         }, [] as Array<ChunkMetadata>)
-        : []
+        : pickupContentFromSourcemap(map)
 
       for (const info of infomations) {
         if (info.id[0] === '.') {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -181,6 +181,7 @@ function analyzer(opts?: AnalyzerPluginOptions): Plugin {
           await analyzerModule.addModule(bundle, sourcemapFileName)
           cleanup.push({ sourcemapFileName, bundle })
         }
+        // await analyzerModule.addModuleV2(bundle)
       }
       if (!store.lastSourcemapOption) {
         cleanup.forEach((b) => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -96,7 +96,7 @@ function analyzer(opts?: AnalyzerPluginOptions): Plugin {
   opts = { ...defaultOptions, ...opts }
 
   const { reportTitle = 'vite-bundle-analyzer' } = opts
-  const analyzerModule = createAnalyzerModule(opts?.gzipOptions)
+  const analyzerModule = createAnalyzerModule({ gzip: opts.gzipOptions, brotli: opts.brotliOptions })
   const store: AnalyzerStore = { analyzerModule, lastSourcemapOption: false, hasSetupSourcemapOption: false }
   let defaultWd = process.cwd()
   let hasViteReporter = true

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,8 +4,8 @@ import path from 'path'
 import { Readable } from 'stream'
 import type { Logger, Plugin } from 'vite'
 import zlib from 'zlib'
-import { AnalyzerNode, createAnalyzerModule } from './analyzer-module'
-import type { AnalyzerPluginOptions, AnalyzerStore, Module, OutputAsset, OutputBundle, OutputChunk } from './interface'
+import { AnalyzerNode, JS_EXTENSIONS, createAnalyzerModule } from './analyzer-module'
+import type { AnalyzerPluginOptions, AnalyzerStore, Module } from './interface'
 import { opener } from './opener'
 import { createServer, ensureEmptyPort, renderView } from './render'
 import { searchForWorkspaceRoot } from './search-root'
@@ -66,19 +66,6 @@ const generateSummaryMessage = (modules: AnalyzerNode[]) => {
     meta.map && `map: ${formatSize(meta.map)}`
   ].filter(Boolean).join(' | ')
   return `${formatNumber(count)} chunks of ${formatSize(meta.parsed)} ${extra ? `(${extra})` : ''}`
-}
-
-function validateChunk(chunk: OutputAsset | OutputChunk, allChunks: OutputBundle): [boolean, string | undefined] {
-  // https://github.com/rollup/rollup/blob/master/CHANGELOG.md#features-22
-  if (/\.(c|m)?js$/.test(chunk.fileName)) {
-    if (chunk && 'sourcemapFileName' in chunk) {
-      if (chunk.sourcemapFileName && chunk.sourcemapFileName in allChunks) { return [true, chunk.sourcemapFileName] }
-    }
-    const possiblePath = chunk.fileName + '.map'
-    if (possiblePath in allChunks) { return [true, possiblePath] }
-    return [true, undefined]
-  }
-  return [false, undefined]
 }
 
 // Design for race condition is called
@@ -169,29 +156,28 @@ function analyzer(opts?: AnalyzerPluginOptions): Plugin {
     async generateBundle(_, outputBundle) {
       analyzerModule.installPluginContext(this)
       analyzerModule.setupRollupChunks(outputBundle)
-      const cleanup: Array<{ bundle: OutputChunk | OutputAsset, sourcemapFileName: string | undefined }> = []
+      // const cleanup: Array<{ bundle: OutputChunk | OutputAsset, sourcemapFileName: string | undefined }> = []
       // After consider. I trust process chunk is enough. (If you don't think it's right. PR welcome.)
       // A funny thing is that 'Import with Query Suffixes' vite might think the worker is assets
       // So we should wrapper them as a chunk node.
       for (const bundleName in outputBundle) {
         const bundle = outputBundle[bundleName]
-        const [pass, sourcemapFileName] = validateChunk(bundle, outputBundle)
-        if (pass) {
-          // For classical
-          await analyzerModule.addModule(bundle, sourcemapFileName)
-          cleanup.push({ sourcemapFileName, bundle })
-        }
-        // await analyzerModule.addModuleV2(bundle)
+        await analyzerModule.addModule(bundle)
       }
       if (!store.lastSourcemapOption) {
-        cleanup.forEach((b) => {
-          if (b.sourcemapFileName) {
-            Reflect.deleteProperty(outputBundle, b.sourcemapFileName)
+        // https://262.ecma-international.org/5.1/#sec-12.6.4
+        for (const bundleName in outputBundle) {
+          const bundle = outputBundle[bundleName]
+          if (JS_EXTENSIONS.test(bundle.fileName)) {
+            const possiblePath = bundle.fileName + '.map'
+            if (possiblePath in outputBundle) {
+              Reflect.deleteProperty(outputBundle, possiblePath)
+            }
+            if (bundle.type === 'chunk') {
+              Reflect.deleteProperty(bundle, 'map')
+            }
           }
-          if (b.bundle.type === 'chunk') {
-            Reflect.deleteProperty(b, 'map')
-          }
-        })
+        }
       }
     },
     async closeBundle() {

--- a/src/server/interface.ts
+++ b/src/server/interface.ts
@@ -1,5 +1,5 @@
 import type { HookHandler, Plugin } from 'vite'
-import type { ZlibOptions } from 'zlib'
+import type { BrotliOptions, ZlibOptions } from 'zlib'
 import { AnalyzerModule } from './analyzer-module'
 
 type RenderChunkFunction = NonNullable<HookHandler<Plugin['renderChunk']>>
@@ -22,7 +22,7 @@ export type ModuleInfo = NonNullable<ReturnType<PluginContext['getModuleInfo']>>
 
 export type AnalyzerMode = 'static' | 'json' | 'server'
 
-export type DefaultSizes = 'stat' | 'parsed' | 'gzip'
+export type DefaultSizes = 'stat' | 'parsed' | 'gzip' | 'brotli'
 
 export interface Module {
   label: string
@@ -32,6 +32,7 @@ export interface Module {
   parsedSize: number
   mapSize: number
   gzipSize: number
+  brotliSize: number
   source: Array<Module>
   stats: Array<Module>
   imports: Array<string>
@@ -47,6 +48,7 @@ export interface BasicAnalyzerPluginOptions {
   reportTitle?: string
   defaultSizes?: DefaultSizes
   gzipOptions?: ZlibOptions
+  brotliOptions?: BrotliOptions
 }
 
 export interface AnalyzerPluginOptionsWithServer extends BasicAnalyzerPluginOptions {

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 import path from 'path'
 import utils from 'util'
 import zlib from 'zlib'
-import type { InputType, ZlibOptions } from 'zlib'
+import type { BrotliOptions, InputType, ZlibOptions } from 'zlib'
 
 export * from '../shared'
 
@@ -12,16 +12,26 @@ export const fsp = fs.promises
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
 const gzip = utils.promisify(zlib.gzip)
+const brotli = utils.promisify(zlib.brotliCompress)
 
 const defaultGzipOptions = <ZlibOptions> {
   level: zlib.constants.Z_DEFAULT_LEVEL
 }
 
+const defaultBrotliOptions = <BrotliOptions> {
+  params: {
+    [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY
+  }
+}
+
 export function createGzip(options: ZlibOptions = {}) {
   options = Object.assign(defaultGzipOptions, options)
-  return (buf: InputType) => {
-    return gzip(buf, options)
-  }
+  return (buf: InputType) => gzip(buf, options)
+}
+
+export function createBrotil(options: BrotliOptions = {}) {
+  options = Object.assign(defaultBrotliOptions, options)
+  return (buf: InputType) => brotli(buf, options)
 }
 
 // MIT License

--- a/src/server/trie.ts
+++ b/src/server/trie.ts
@@ -12,6 +12,7 @@ export interface KindStat {
 
 export interface KindSource {
   parsedSize: number
+  brotliSize: number
   gzipSize: number
 }
 
@@ -110,8 +111,9 @@ export class FileSystemTrie<T> {
             const size = child.groups.reduce((acc, cur) => {
               acc.parsedSize += cur.parsedSize
               acc.gzipSize += cur.gzipSize
+              acc.brotliSize += cur.brotliSize
               return acc
-            }, { parsedSize: 0, gzipSize: 0 })
+            }, { parsedSize: 0, gzipSize: 0, brotliSize: 0 })
             Object.assign(child, size)
           }
         }


### PR DESCRIPTION
# Background

This pull request will add some feature for server and client.

### CheckList

- [x] Brotli Alorithm.
- [x] Process assets.
- [ ] Add path reference to the module? (I'm not sure if it's necessary)
- [ ] Deprecate current client zoom behavior?

### Relative 

#51 


### Others

Such as add path reference to module and deprecate zoom behavior and etc, I'm not sure if it makes sense. If we deprecate the zoom behavior, in MacOS and using magic trackpad we can using `three finger` to zoom it (Currently is scale) or using `two finger` to zoom it(But this i have not enough time to do, It will take some times.) or using Windows system with a keyboard can using `ctrl` + mouse wheel to zooming.

If we deprecate zoom with click. we can apply new event for click, like display a full log for module.(Like path reference, original source code place.)
