### PR TITLE
Use console in place of logger in server config hook

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -114,7 +114,7 @@ function analyzer(opts?: AnalyzerPluginOptions) {
           : config.build.sourcemap === 'hidden'
         if (config.build.sourcemap === 'inline') {
           // verbose the warning
-          logger.warn('vite-bundle-analyzer: sourcemap option is set to `inline`, it might cause the result inaccurate.')
+          console.warn('vite-bundle-analyzer: sourcemap option is set to `inline`, it might cause the result inaccurate.')
         }
       }
       if (config.build) {


### PR DESCRIPTION
Logger is not defined when trying to warn about inline sourcemaps

Fixes #57 