### PR TITLE
feat: add support for `enabled` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ export default defineConfig({
 | `openAnalyzer` | `boolean`                        | `true`        | Open the static website. (Only works on `analyzerMode` is `server` or `static` ) |
 | `defaultSizes` | `stat\|parsed\|gzip\brotil`      | `stat`        | The default type selected in the client page                                     |
 | `summary`      | `boolean`                        | `true`        | Show full chunk info to stdout.                                                  |
+| `enabled`      | `boolean`                        | `true`        | Whether to enable this plugin.                                                 |
 
 ## ClI
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -14,6 +14,7 @@ import { analyzerDebug, arena, convertBytes, fsp } from './shared'
 export const isCI = !!process.env.CI
 
 const defaultOptions: AnalyzerPluginOptions = {
+  enabled: true,
   analyzerMode: 'server',
   defaultSizes: 'stat',
   summary: true
@@ -164,6 +165,10 @@ export async function createAnalyzerServer(
 
 function analyzer(opts?: AnalyzerPluginOptions) {
   opts = { ...defaultOptions, ...opts }
+
+  if(!opts.enabled) {
+    return
+  }
 
   const { reportTitle = 'vite-bundle-analyzer' } = opts
   const analyzerModule = createAnalyzerModule({ gzip: opts.gzipOptions, brotli: opts.brotliOptions })

--- a/src/server/interface.ts
+++ b/src/server/interface.ts
@@ -43,6 +43,7 @@ export interface Module {
 export type CustomAnalyzerModule = (analyzeModule: Module[]) => void
 
 export interface BasicAnalyzerPluginOptions {
+  enabled?: boolean
   summary?: boolean
   analyzerMode?: AnalyzerMode | CustomAnalyzerModule
   reportTitle?: string


### PR DESCRIPTION
resolves https://github.com/nonzzz/vite-bundle-analyzer/issues/64

❗Notice that the return of the `analyzer` function will change from `Plugin<AnalyzerPluginInternalAPI>` to `Plugin<AnalyzerPluginInternalAPI> | undefined` because of the early return.
Not sure how this sounds to you 🤔. Otherwise we might need to return an empty plugin object: `return { name: 'vite-bundle-anlyzer' } as Plugin<AnalyzerPluginInternalAPI>`, or add early return in every hook the plugin.