### PR TITLE
fix: typo in plugin name

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -193,7 +193,7 @@ function analyzer(opts?: AnalyzerPluginOptions) {
   }
 
   const base = {
-    name: 'vite-bundle-anlyzer',
+    name: 'vite-bundle-analyzer',
     apply: 'build',
     enforce: 'post',
     api: {


### PR DESCRIPTION
Hello

We detect a typo in the plugin name that does not match the package name.

This PR fix it.